### PR TITLE
Update src/main/java/br/com/digilabs/jqplot/elements/RendererOptions.jav...

### DIFF
--- a/src/main/java/br/com/digilabs/jqplot/elements/RendererOptions.java
+++ b/src/main/java/br/com/digilabs/jqplot/elements/RendererOptions.java
@@ -95,6 +95,9 @@ public class RendererOptions implements Element {
     /** The fill. */
     private Boolean fill;
     
+    /** The fillToZero */
+    private Boolean fillToZero;
+    
     /** The smooth. */
     private Boolean smooth;
     
@@ -223,6 +226,24 @@ public class RendererOptions implements Element {
      */
     public void setFill(Boolean fill) {
         this.fill = fill;
+    }
+    
+    /**
+     * Gets the fillToZero.
+     *
+     * @return fillToZero true ou false
+     */
+    public Boolean getFillToZero() {
+        return fillToZero;
+    }
+
+    /**
+     * Sets the fillToZero.
+     *
+     * @param fillToZero the new fillToZero
+     */
+    public void setFillToZero(Boolean fillToZero) {
+        this.fillToZero = fillToZero;
     }
 
     /**


### PR DESCRIPTION
I added fillToZero (Boolean) property.
It's usefull for BarChart with negative values.
Without a fillToZero set to true, the BarChart will render negative values in the same "Orientation" than positive values.

I attached two screenshot (before and after).

![barchar negative value before](https://f.cloud.github.com/assets/2108652/145576/3b50004e-7469-11e2-9ade-552b53c104ed.png)
![barchar negative value after](https://f.cloud.github.com/assets/2108652/145577/40d70ac6-7469-11e2-9a2a-fca8a888e15c.png)

PS: You made a nice project, it really save us a lot of time here ! :)
