### PR TITLE
Change getter of rendererOptions to correct one

### DIFF
--- a/src/main/java/br/com/digilabs/jqplot/chart/AbstractChart.java
+++ b/src/main/java/br/com/digilabs/jqplot/chart/AbstractChart.java
@@ -413,7 +413,7 @@ public abstract class AbstractChart<T extends ChartData<?>, S extends Serializab
 	 * @return AbstractChart
 	 */
 	public AbstractChart<T, S> setFillZero(Boolean fillZero) {
-		getChartConfiguration().seriesDefaultsInstance().getRendererOptions()
+		getChartConfiguration().seriesDefaultsInstance().rendererOptionsInstance()
 				.setFillZero(fillZero);
 		return this;
 	}


### PR DESCRIPTION
Hello, previous getter returns null pointer because it is like an old getter which was without new instance.

New method is rendererOptionsInstance() - singleton that will always return an object.