### PR TITLE
Return visibility of percentage label on PieChart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -144,6 +145,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -157,6 +159,27 @@
                     </execution>
                 </executions>
             </plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id> <!-- this is used for inheritance merges -->
+						<phase>package</phase> <!-- bind to the packaging phase -->
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>br.com.digilabs.jqplot</groupId>
 	<artifactId>jqplot4java</artifactId>
-	<version>1.3.2-SNAPSHOT</version>
+	<version>1.3.2-javascript</version>
 	<packaging>jar</packaging>
 
 	<name>jqplot4java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -117,20 +117,7 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
 			<plugin>
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/br/com/digilabs/jqplot/chart/PieChart.java
+++ b/src/main/java/br/com/digilabs/jqplot/chart/PieChart.java
@@ -56,7 +56,7 @@ public class PieChart<T extends Number> extends AbstractChart<PieData<T>,String>
     		.seriesDefaultsInstance()
     		.setRenderer(JqPlotResources.PieRenderer)
     		.rendererOptionsInstance()
-    		.setShowLables(true);
+            .setShowDataLabels(true);
     }
 
     /**


### PR DESCRIPTION
Hello, in my project I saw PieChart with percentages on version 1.2.3.
JS code that had been generated on 1.2.3 version:

$(document).ready(function(){
   $.jqplot('task-status', [[["Finished (0 tasks)",0],["In progress (0 tasks)",0],["Ready to start (1 tasks)",100],["Blocked (0 tasks)",0]]], {
  "title": {
    "text": "Task Status"
  },
  "seriesDefaults": {
    "renderer": $.jqplot.PieRenderer,
    "rendererOptions": {
      "**showDataLabels**": true,
      "seriesColors": [
        "#d599e8",
        "#4c99e8",
        "#8fbe86",
        "#ffbb6b"
      ]
    }
  },
  "legend": {
    "location": "e",
    "show": true
  }
});
});

In version 1.3.1 generated JS code became:

$(document).ready(function(){
   $.jqplot('task-status', [[["Finished (0 tasks)",0],["In progress (0 tasks)",0],["Ready to start (1 tasks)",100],["Blocked (0 tasks)",0]]], {
  "title": {
    "text": "Task Status"
  },
  "seriesDefaults": {
    "renderer": $.jqplot.PieRenderer,
    "rendererOptions": {
      "**showLables**": true,
      "seriesColors": [
        "#d599e8",
        "#4c99e8",
        "#8fbe86",
        "#ffbb6b"
      ]
    }
  },
  "legend": {
    "location": "e",
    "show": true
  }
});
});

As I see it is because of PieChart constructor:

public PieChart(String title) {
        this.chartConfig = new ChartConfiguration<String>();
        chartConfig
            .setTitle(new Title(title))
            .setLegend(new Legend(true, Location.e))
            .seriesDefaultsInstance()
            .setRenderer(JqPlotResources.PieRenderer)
            .rendererOptionsInstance()
            **.setShowLables(true);**
    }
